### PR TITLE
Catch BiometricPrompt exception

### DIFF
--- a/app/src/main/kotlin/com/saltedge/authenticator/widget/biometric/BiometricPromptManagerV28.kt
+++ b/app/src/main/kotlin/com/saltedge/authenticator/widget/biometric/BiometricPromptManagerV28.kt
@@ -28,9 +28,9 @@ import android.os.CancellationSignal
 import androidx.annotation.RequiresApi
 import androidx.annotation.StringRes
 import androidx.fragment.app.FragmentActivity
-import com.crashlytics.android.Crashlytics
 import com.saltedge.authenticator.R
 import com.saltedge.authenticator.tool.ResId
+import com.saltedge.authenticator.tool.log
 
 /**
  * A handler class which start and manage callbacks from BiometricPrompt.
@@ -68,7 +68,7 @@ class BiometricPromptManagerV28 : BiometricPromptAbs, DialogInterface.OnClickLis
                 val prompt: BiometricPrompt = builder.build()
                 prompt.authenticate(it, context.mainExecutor, authenticationCallBack)
             } catch (e: Exception) {
-                Crashlytics.logException(e)
+                e.log()
                 cancelPrompt()
             }
         }
@@ -78,7 +78,7 @@ class BiometricPromptManagerV28 : BiometricPromptAbs, DialogInterface.OnClickLis
         try {
             cancellationSignal?.cancel()
         } catch (e: Exception) {
-            Crashlytics.logException(e)
+            e.log()
         }
     }
 

--- a/app/src/main/kotlin/com/saltedge/authenticator/widget/biometric/BiometricPromptManagerV28.kt
+++ b/app/src/main/kotlin/com/saltedge/authenticator/widget/biometric/BiometricPromptManagerV28.kt
@@ -28,6 +28,7 @@ import android.os.CancellationSignal
 import androidx.annotation.RequiresApi
 import androidx.annotation.StringRes
 import androidx.fragment.app.FragmentActivity
+import com.crashlytics.android.Crashlytics
 import com.saltedge.authenticator.R
 import com.saltedge.authenticator.tool.ResId
 
@@ -63,8 +64,21 @@ class BiometricPromptManagerV28 : BiometricPromptAbs, DialogInterface.OnClickLis
                 context.mainExecutor,
                 this
             )
-            val prompt: BiometricPrompt = builder.build()
-            prompt.authenticate(it, context.mainExecutor, authenticationCallBack)
+            try {
+                val prompt: BiometricPrompt = builder.build()
+                prompt.authenticate(it, context.mainExecutor, authenticationCallBack)
+            } catch (e: Exception) {
+                Crashlytics.logException(e)
+                cancelPrompt()
+            }
+        }
+    }
+
+    private fun cancelPrompt() {
+        try {
+            cancellationSignal?.cancel()
+        } catch (e: Exception) {
+            Crashlytics.logException(e)
         }
     }
 


### PR DESCRIPTION
Crash trace:
```
Caused by android.os.RemoteException: Remote stack trace:
	at com.android.server.fingerprint.FingerprintService.isForegroundActivity(FingerprintService.java:786)
	at com.android.server.fingerprint.FingerprintService.canUseFingerprint(FingerprintService.java:824)
	at com.android.server.fingerprint.FingerprintService.access$1900(FingerprintService.java:102)
	at com.android.server.fingerprint.FingerprintService$FingerprintServiceWrapper.authenticate(FingerprintService.java:1197)
	at android.hardware.fingerprint.IFingerprintService$Stub.onTransact(IFingerprintService.java:74)
```