### PR TITLE
Doesn't launch QR scan if enrollment process was started via the deep…

### DIFF
--- a/app/src/main/kotlin/com/saltedge/authenticator/features/main/MainActivityViewModel.kt
+++ b/app/src/main/kotlin/com/saltedge/authenticator/features/main/MainActivityViewModel.kt
@@ -125,6 +125,7 @@ class MainActivityViewModel(
                 )
             }
             intent.hasDeepLinkData -> {
+                initialQrScanWasStarted = true
                 intent.deepLink.extractConnectAppLinkData()?.let { connectionAppLinkData ->
                     onShowConnectEvent.postValue(ViewModelEvent(Bundle().apply {
                         putSerializable(KEY_DATA, connectionAppLinkData)


### PR DESCRIPTION
…link

**Related Issue**  
https://github.com/saltedge/sca-authenticator-android/issues/239