### PR TITLE
Remove Robolectric `shadows-playservices` dependency

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -162,7 +162,6 @@ dependencies { //TODO After changing dependencies list, review third-party libra
     testImplementation 'androidx.test:core:1.4.0'
     testImplementation 'org.jetbrains.kotlinx:kotlinx-coroutines-test:1.4.2'
     testImplementation 'org.robolectric:robolectric:4.3.1'
-    testImplementation 'org.robolectric:shadows-playservices:4.3'
     testImplementation 'org.mockito:mockito-core:3.2.4'
     testImplementation "io.mockk:mockk:1.10.2"
     testImplementation project(':test_tools')


### PR DESCRIPTION
**Related Issue**

N/A

**Proposed Changes**

- Remove the `org.robolectric:shadows-playservices` dependency as it may not be necessary.

**Additional Info** 

I am going through projects using the `org.robolectric:shadows-playservices` dependency, to see if it is possible to remove it. It seems that it may not be needed in this project.

***NOTE***

I wasn't able to get the Realm dependency locally, so I couldn't test my change before creating the PR.